### PR TITLE
Fix command line to install requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To download the necessary requirements, `git clone` this repository and run this
 ```python
 pip install -r  requirements.txt
 ```
-This should work in a Conda environment to, but I'm not certain of that.
+This will also work in a Conda environment, although it is not the preferred way of installing dependings in Conda.
 
 The `cfgrib` library, which we use to load GRIB2 files, may require [some additional tools](https://github.com/ecmwf/cfgrib) for setup. If you are running MacOS, you can install this extra stuff using this command:
 ```python

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project works mainly with NDFD Grid Data, but NDFD Point Access Data is ava
 # Requirements
 To download the necessary requirements, `git clone` this repository and run this command:
 ```python
-pip install requirements.txt
+pip install -r  requirements.txt
 ```
 This should work in a Conda environment to, but I'm not certain of that.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.18.1
-pandas==1.0.1
+numpy
+pandas
 cfgrib==0.9.7.7
-xarray==0.15.0
+xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
-pandas
-cfgrib==0.9.7.7
-xarray
+numpy>=1.18.1
+pandas>=1.0.1
+cfgrib>=0.9.7.7
+xarray>=0.15.0


### PR DESCRIPTION
Very minor fix. Fix doc to indicate you need -r command line option for pip to install from a requirements.txt file, as the existing doc will not run as expected.